### PR TITLE
[Java] CI Actions Setup for Backend Building and Linting

### DIFF
--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -1,10 +1,6 @@
-name: Build and lint Java on Jesse branches
+name: Build and lint Java
 
 on:
-  push:
-    branches:
-      - 'jesse/**'
-      - 'adam/**'
   pull_request:
     branches:
       - 'main'


### PR DESCRIPTION
PR adds Github actions workflow for building all backend components with Java and linting with super linter.

Notes on building: 
- We can add tests here when written.
- Jar is used for serverless framework deployment (will set this up next)

Notes on linting:
- Currently only lint Java files. Swift is not supported by this linter. We'll need to pull in a different tool for this.
- We give GitHub token to get direct status comments in PR. Super-Linter is maintained by GitHub so I think this is not an issue.
- Build and lint takes about 2 mins. We have 3000 a month so I don't foresee this becoming an issue. Currently set to run only on pull requests. We can run locally using [local linter setup instructions](https://github.com/github/super-linter/blob/master/docs/run-linter-locally.md).

We're currently failing Java linting, so these issues will have to be resolved. However, this PR is for the CI workflow and not Java code, so I think we should merge this and fix formatting issues in new PR.

TODO for CI/CD: Add swift lint, add deploy to AWS on push to main.

Related issue: #14 