### PR TITLE
Deploy to AWS continously

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to AWS on push to main
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'backend/**'
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build project with Maven
+        working-directory: ./backend/TutorTrade
+        run: mvn clean install
+      - name: serverless deploy
+        uses: serverless/github-action@master
+        with:
+          args: deploy
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SERVICE_ROOT: ./backend/TutorTrade


### PR DESCRIPTION
This PR adds an action to deploy the backend service (defined in serverless.yml) every time we have a push to main where a file in the backend directory has been modified. Doing so will require that we add AWS keys to GitHub secrets. Note that the GitHub action is [maintained officially by Severless ](https://github.com/serverless/github-action), so I don't see a security concern, but I want to make sure everyone is okay with this before adding the keys.

Once everyone has approved the PR, I'll add the keys to secrets and then merge. Future pushes will then trigger deployment.

Merging this PR will close #14. 