### PR TITLE
Fixed Bugged RequestHandler Error Response

### DIFF
--- a/backend/TutorTrade/src/main/java/com/tutor/request/RequestsHandler.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/request/RequestsHandler.java
@@ -26,7 +26,6 @@ public class RequestsHandler implements RequestHandler<Map<Object, Object>, Stri
   private static final AmazonDynamoDB DYNAMO_DB =
       AmazonDynamoDBClientBuilder.standard().withRegion(Regions.US_EAST_1).build();
   private static final DynamoDBMapper MAPPER = new DynamoDBMapper(DYNAMO_DB);
-  private static final int HTTP_UNPROCESSABLE_ENTITY = 422;
 
   @Override
   public String handleRequest(Map<Object, Object> event, Context context) {
@@ -53,7 +52,7 @@ public class RequestsHandler implements RequestHandler<Map<Object, Object>, Stri
       } catch (RequestBuilderException e) {
         e.printStackTrace();
         return getResponseAsString(
-                HTTP_UNPROCESSABLE_ENTITY,
+                HttpURLConnection.HTTP_BAD_REQUEST,
                 e.getMessage());
       }
     }


### PR DESCRIPTION
# What?
Small PR that fixes #36.

# Reproduce Fix
Previously, the following `POST` would produce an incorrect string (see issue #36). Now, here's what is returned. Note that HTTP 422 is ["unprocessable entity"](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422), which makes sense.

**Body**
```json
{
    "requesterId": "3bba676a-4f4c-4bc9-acfc-87808d348a81",
    "subject": "UNSUPPORTED",
    "costInPoints": "550",
    "urgency": "IMMEDIATE",
    "platform": "ONLINE"
}
```

**Response**
```json
"{\"statusCode\":422,\"headers\":null,\"multiValueHeaders\":null,\"cookies\":null,\"body\":\"Subject is unsupported\",\"isBase64Encoded\":false}"
```

# Testing
Tested via Postman in my dev stage.