### PR TITLE
Modify subject handler to return list of subjects

### DIFF
--- a/backend/TutorTrade/src/main/java/com/tutor/request/Subject.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/request/Subject.java
@@ -1,6 +1,5 @@
 package com.tutor.request;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -68,10 +67,9 @@ public enum Subject {
   /**
    * Returns a list with all the subject names and emojis
    *
-   * @return
-   * @throws JsonProcessingException
+   * @return List of subjects
    */
-  public static List<String> getListOfSubjects() throws JsonProcessingException {
+  public static List<String> getListOfSubjects() {
     return Arrays.stream(Subject.values()).map(Subject::toString).collect(Collectors.toList());
   }
 }

--- a/backend/TutorTrade/src/main/java/com/tutor/subjects/SubjectsHandler.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/subjects/SubjectsHandler.java
@@ -2,11 +2,9 @@ package com.tutor.subjects;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.tutor.request.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,12 +19,7 @@ public class SubjectsHandler implements RequestHandler<Map<Object, Object>, List
     String httpMethod = (String) contextMap.get("http-method");
 
     if (httpMethod.equals("GET")) {
-      try {
-        return Subject.getListOfSubjects();
-      } catch (JsonProcessingException e) {
-        e.printStackTrace();
-        return null;
-      }
+      return Subject.getListOfSubjects();
     }
     return null;
   }


### PR DESCRIPTION
Returning list of strings preserves emoji encoding, and prevents lambda from double serializing output. There is a short-term solution until @Quikks1lver and I have a chance to refactor handlers and return custom APIResponse types.

**Testing**
Deploying to dev branch and made request to /subjects endpoint. Sample response.

`Request: /subjects
Status: 200
Latency: 1635 ms
Response Body
[
  "🌾 Agriculture",
  "🪐 Astronomy",
  "🧪 Chemistry",
  "📍 Geography",
  "🧬 Biology",
  "🔎 Forensic Science",
  "🧱 Materials",
  "⚛️ Physics",
  "☣️ Biomedical Sciences",
  "🌍 Environmental Sciences",
  "🏈 Sports Science",
  "➗ Mathematics",
  "🏛 Architecture",
  "🏗 Construction",
  "🧾 Accounting",
  "📊 Business",
  "💵 Finance",
  "📈 Marketing",
  "🛍 Retail",
  "🙋 Human Resources",
  "💻 Computer Science",
  "💾 IT",
  "🎨 Art",
  "🎵 Music",
  "⿴ Graphic Design",
  "🎭 Theatre",
  "👩‍🏫 Education",
  "🚉 Civil Engineering",
  "🧠 Psychology",
  "👩🏻‍⚕️ Nursing",
  "💪 Physiology",
  "🤔 Philosophy",
  "🔤 Languages",
  "🦖 Archaeology",
  "📚 Literature",
  "🕰 History",
  "🙏 Religion",
  "📖 Law",
  "✍️ Journalism",
  "🗳 Politics",
  "🏨 Hospitality",
  "✈️ Aviation",
  "🤷 UNSUPPORTED"
]`