### PR TITLE
Changed lambda handlers to return custom API response

### DIFF
--- a/backend/TutorTrade/pom.xml
+++ b/backend/TutorTrade/pom.xml
@@ -76,6 +76,12 @@
             <artifactId>commons-math3</artifactId>
             <version>3.6.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.22</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -119,7 +125,15 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/backend/TutorTrade/serverless.yml
+++ b/backend/TutorTrade/serverless.yml
@@ -133,12 +133,12 @@ functions:
             Fn::GetAtt: [ requestsTable, StreamArn ]
           maximumRetryAttempts: 1
   subjects:
-    handler: com.tutor.subjects.SubjectsHandler
+    handler: com.tutor.subject.SubjectsHandler
     environment:
       STAGE: ${self:provider.stage}
     events:
       - http:
-          path: /subjects/
+          path: /subject/
           method: get
           integration: lambda
           request:

--- a/backend/TutorTrade/src/main/java/com/tutor/request/Request.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/request/Request.java
@@ -1,6 +1,8 @@
 package com.tutor.request;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.*;
+import com.tutor.subject.Subject;
+
 import java.time.LocalDateTime;
 import java.util.UUID;
 

--- a/backend/TutorTrade/src/main/java/com/tutor/request/RequestBuilder.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/request/RequestBuilder.java
@@ -1,5 +1,7 @@
 package com.tutor.request;
 
+import com.tutor.subject.Subject;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -46,8 +48,6 @@ public class RequestBuilder {
 
     if (!nullValues.isEmpty()) {
       throw new RequestBuilderException("No values provided for these fields: " + nullValues);
-    } else if (request.getSubject() == Subject.UNSUPPORTED) {
-      throw new RequestBuilderException("Subject is unsupported");
     }
   }
 
@@ -61,8 +61,12 @@ public class RequestBuilder {
     return this;
   }
 
-  public RequestBuilder withSubject(String subject) {
-    this.subject = Subject.valueOf(subject);
+  public RequestBuilder withSubject(String subject) throws RequestBuilderException {
+    try {
+      this.subject = Subject.valueOf(subject);
+    } catch (IllegalArgumentException e) {
+      throw new RequestBuilderException(String.format("Subject %s is unsupported.", subject));
+    }
     return this;
   }
 

--- a/backend/TutorTrade/src/main/java/com/tutor/subject/Subject.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/subject/Subject.java
@@ -1,4 +1,4 @@
-package com.tutor.request;
+package com.tutor.subject;
 
 import java.util.Arrays;
 import java.util.List;
@@ -50,8 +50,7 @@ public enum Subject {
   JOURNALISM("✍️ Journalism"),
   POLITICS("🗳 Politics"),
   HOSPITALITY("🏨 Hospitality"),
-  AVIATION("✈️ Aviation"),
-  UNSUPPORTED("🤷 UNSUPPORTED");
+  AVIATION("✈️ Aviation");
 
   private final String subjectName;
 
@@ -59,8 +58,7 @@ public enum Subject {
     this.subjectName = subjectName;
   }
 
-  @Override
-  public String toString() {
+  public String getSubjectName() {
     return this.subjectName;
   }
 
@@ -70,6 +68,6 @@ public enum Subject {
    * @return List of subjects
    */
   public static List<String> getListOfSubjects() {
-    return Arrays.stream(Subject.values()).map(Subject::toString).collect(Collectors.toList());
+    return Arrays.stream(Subject.values()).map(Subject::getSubjectName).collect(Collectors.toList());
   }
 }

--- a/backend/TutorTrade/src/main/java/com/tutor/subject/SubjectsHandler.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/subject/SubjectsHandler.java
@@ -1,27 +1,29 @@
-package com.tutor.subjects;
+package com.tutor.subject;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
-import com.tutor.request.Subject;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import com.tutor.utils.ApiResponse;
+import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /** Handle requests to the Subjects endpoint. Currently only supports get requests. */
-public class SubjectsHandler implements RequestHandler<Map<Object, Object>, List<String>> {
+public class SubjectsHandler implements RequestHandler<Map<Object, Object>, ApiResponse<?>> {
   private static final Logger LOG = LogManager.getLogger(SubjectsHandler.class);
 
   @Override
-  public List<String> handleRequest(Map<Object, Object> event, Context context) {
+  public ApiResponse<?> handleRequest(Map<Object, Object> event, Context context) {
     HashMap<?, ?> contextMap = (HashMap<?, ?>) event.get("context");
     String httpMethod = (String) contextMap.get("http-method");
 
     if (httpMethod.equals("GET")) {
-      return Subject.getListOfSubjects();
+      return ApiResponse.<List<String>>builder()
+          .statusCode(HttpURLConnection.HTTP_OK)
+          .body(Subject.getListOfSubjects())
+          .build();
     }
     return null;
   }

--- a/backend/TutorTrade/src/main/java/com/tutor/utils/ApiResponse.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/utils/ApiResponse.java
@@ -1,0 +1,16 @@
+package com.tutor.utils;
+
+import lombok.Builder;
+
+/**
+ * Class wraps API response to allow us to return status code information and arbitrary objects from
+ * lambda handlers.
+ *
+ * @param <T> Data type of body. This object will be serialized and returned as API response.
+ *     Typically, string for error messages, or request/user/subjects on successful API calls.
+ */
+@Builder
+public class ApiResponse<T> {
+  public int statusCode;
+  public T body;
+}

--- a/backend/TutorTrade/src/main/java/com/tutor/utils/ApiUtils.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/utils/ApiUtils.java
@@ -1,8 +1,5 @@
 package com.tutor.utils;
 
-import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
@@ -95,30 +92,10 @@ public class ApiUtils {
     return "Encountered error. See stack trace.";
   }
 
-  /**
-   * Returns an API response with status code and body as a string
-   * with valid JSON format.
-   *
-   * @param statusCode HTTP status code.
-   * @param body string for the body of the response.
-   * @return string response.
-   */
-  public static String getResponseAsString(int statusCode, String body) {
-    APIGatewayV2HTTPResponse response = new APIGatewayV2HTTPResponse();
-    response.setStatusCode(statusCode);
-    response.setBody(body);
-
-    ObjectMapper mapper = new ObjectMapper();
-
-    try {
-      return mapper.writeValueAsString(response);
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-      return "Status Code: 400. Response was malformed." + response;
-    }
-  }
-
-  public static String returnErrorString(Exception ex) {
-    return ApiUtils.getResponseAsString(HttpURLConnection.HTTP_BAD_REQUEST, ex.getMessage());
+  public static ApiResponse<String> returnErrorResponse(Exception ex) {
+    return ApiResponse.<String>builder()
+            .statusCode(HttpURLConnection.HTTP_OK)
+            .body(ex.toString())
+            .build();
   }
 }

--- a/backend/TutorTrade/src/main/java/com/tutor/utils/RequestUtils.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/utils/RequestUtils.java
@@ -7,10 +7,9 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.tutor.request.Platform;
 import com.tutor.request.Request;
-import com.tutor.request.Subject;
+import com.tutor.subject.Subject;
 import com.tutor.request.Urgency;
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.util.*;
 
 /** Utility class for operations on request objects. */
@@ -70,33 +69,6 @@ public class RequestUtils {
 
     System.out.println(
         ApiUtils.post(ApiUtils.ApiStages.valueOf(stage).toString(), "/request/create", json));
-  }
-
-  /**
-   * Method finds request in DB and returns an API response with request.
-   *
-   * @param requestId UUID representing a valid and existing request
-   * @return API response with HTTP_OK and request as body, if request is found, response with error
-   *     code otherwise
-   */
-  public static String getRequestById(String requestId) {
-    Request key = new Request(UUID.fromString(requestId));
-    DynamoDBQueryExpression<Request> queryExpression =
-        new DynamoDBQueryExpression<Request>().withHashKeyValues(key);
-
-    List<Request> requestById = DYNAMO_DB_MAPPER.query(Request.class, queryExpression);
-
-    if (requestById.size() == 0) {
-      return ApiUtils.getResponseAsString(HttpURLConnection.HTTP_NOT_FOUND, "Request not found.");
-    } else if (requestById.size() > 1) {
-      return ApiUtils.getResponseAsString(
-          HttpURLConnection.HTTP_CONFLICT,
-          String.format(
-              "Found %d requests with id: %s. 1 expected.", requestById.size(), requestId));
-    }
-
-    // found only 1 request with ID, as desired
-    return ApiUtils.getResponseAsString(HttpURLConnection.HTTP_OK, requestById.get(0).toString());
   }
 
   /**

--- a/backend/TutorTrade/src/main/java/com/tutor/utils/UserUtils.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/utils/UserUtils.java
@@ -17,32 +17,6 @@ public class UserUtils {
   private static final DynamoDBMapper MAPPER = new DynamoDBMapper(DYNAMO_DB);
 
   /**
-   * Method finds request in DB and returns an API response with user.
-   *
-   * @param userId UUID representing a valid and existing user
-   * @return API response with HTTP_OK and request as body, if user is found, response with error
-   *     code otherwise
-   */
-  public static String getUserById(String userId) {
-    User key = new User(UUID.fromString(userId));
-    DynamoDBQueryExpression<User> queryExpression =
-        new DynamoDBQueryExpression<User>().withHashKeyValues(key);
-
-    List<User> userById = MAPPER.query(User.class, queryExpression);
-
-    if (userById.size() == 0) {
-      return ApiUtils.getResponseAsString(HttpURLConnection.HTTP_NOT_FOUND, "User not found.");
-    } else if (userById.size() > 1) {
-      return ApiUtils.getResponseAsString(
-          HttpURLConnection.HTTP_CONFLICT,
-          String.format("Found %d users with id: %s. 1 expected.", userById.size(), userId));
-    }
-
-    // found only 1 user with ID, as desired
-    return ApiUtils.getResponseAsString(HttpURLConnection.HTTP_OK, userById.get(0).toString());
-  }
-
-  /**
    * Method finds user in DB and returns the corresponding user as a Java object.
    *
    * @param userId UUID representing a valid and existing user


### PR DESCRIPTION
Modified all in-use lambda handler methods to return custom API response object, avoiding serialization issues we've encountered. Three small refactors: moved subject enum to subject directory and renamed subjects directory to subject to maintain consistency with rest of project, changed user dateRequested to LocalDateTime.

All API calls now return 
```
{
    statusCode: code,
    body: {}
}
```
with formatted printing.
Example response:

```
{
  "statusCode": 200,
  "body": {
    "name": "jesse",
    "school": "ucf",
    "dateCreated": {
      "nano": 354367000,
      "year": 2021,
      "monthValue": 10,
      "dayOfMonth": 15,
      "hour": 22,
      "minute": 14,
      "second": 29,
      "month": "OCTOBER",
      "dayOfWeek": "FRIDAY",
      "dayOfYear": 288,
      "chronology": {
        "calendarType": "iso8601",
        "id": "ISO"
      }
    },
    "isActive": true,
    "points": 100,
    "sessionIds": [],
    "userId": "ac0628b4-c92e-45dd-9a08-8e64156426ce"
  }
}
```

**Testing**
Deployed to dev stack and made sample calls to user, request, and subject endpoints. All behaved as expected.

Related Issues: closes #60, closes #54 (no longer necessary to serialize ourselves). 