### PR TITLE
Fix testing failure during deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,9 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build project with Maven
+        env:
+          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID_GITHUB }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_GITHUB }}
         working-directory: ./backend/TutorTrade
         run: mvn clean install
       - name: Install Serverless


### PR DESCRIPTION
Our test cases require AWS credentials to run as of PR #66 and the deploy script's build action (which runs test cases) didn't have them, resulting in test failures. Credentials are now provided -- this should allow deployment to succeed. 