### PR TITLE
New User Fields: Major, SubjectsTeach, & SubjectsLearn

### DIFF
--- a/backend/TutorTrade/pom.xml
+++ b/backend/TutorTrade/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.tutor</groupId>
     <artifactId>tutor-api</artifactId>
     <packaging>jar</packaging>
-    <version>adam-dev</version>
+    <version>prod</version>
     <name>tutor-api</name>
 
     <properties>

--- a/backend/TutorTrade/serverless.yml
+++ b/backend/TutorTrade/serverless.yml
@@ -15,7 +15,7 @@ provider:
       Resource: "*"
 
   # change stage when deploying dev stack
-  stage: adam-dev
+  stage: prod
   region: us-east-1
 
 package:

--- a/backend/TutorTrade/src/main/java/com/tutor/request/Request.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/request/Request.java
@@ -19,7 +19,7 @@ import java.util.UUID;
  * Request object. Regarding table name: set equal to requestTable-{stage_name} if deploying to non
  * prod stage.
  */
-@DynamoDBTable(tableName = "requestTable-adam-dev")
+@DynamoDBTable(tableName = "requestTable-prod")
 public class Request {
   private UUID requesterId;
   private UUID helperId;

--- a/backend/TutorTrade/src/main/java/com/tutor/user/User.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/user/User.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
  * object before being written to DynamoDB. User data coming from DynamoDB is read into User object.
  * Regarding table name: set equal to userTable-{stage_name} if deploying to none prod stage
  */
-@DynamoDBTable(tableName = "userTable-adam-dev")
+@DynamoDBTable(tableName = "userTable-prod")
 public class User {
   private String name;
 


### PR DESCRIPTION
# What?
This PR closes #77 and closes #79. Added a new String field for User for their major, as well as added a way to show Subjects a user needs help with as well as Subjects they can tutor for.

# More
Example User POST Request. The first 3 fields are necessary; the last 3 are not.
```json
{
    "name": "adam",
    "school": "UCF",
    "phoneNumber": "123-456-7890",
    "subjectsLearn": ["BIOLOGY"],
    "subjectsTeach": ["ASTRONOMY", "AGRICULTURE"],
    "major": "hello"
}
```

# Testing
Via Postman