### PR TITLE
Fix API Stages Prod URI

### DIFF
--- a/backend/TutorTrade/src/main/java/com/tutor/utils/ApiUtils.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/utils/ApiUtils.java
@@ -16,7 +16,10 @@ import org.apache.http.util.EntityUtils;
 
 /** Utility classes for making GET and POST requests to tutor API. */
 public class ApiUtils {
-  /** Mapping of stage names to API URIs for easy access. */
+  /**
+   * Mapping of stage names to API URIs for easy access. Check the URIs every so often to ensure
+   * they match with what URIs are known to exist for each stage.
+   */
   public enum ApiStages {
     JESSE_DEV("https://bpbzrj9x3b.execute-api.us-east-1.amazonaws.com/jesse-dev"),
     ADAM_DEV("https://qd8wpigd90.execute-api.us-east-1.amazonaws.com/adam-dev"),
@@ -36,9 +39,7 @@ public class ApiUtils {
     }
   }
 
-  /**
-   * Given lambda's STAGE variable, returns the associated URI
-   */
+  /** Given lambda's STAGE variable, returns the associated URI */
   public static String getApiStageUriFromStageEnvVariable(String stage) {
     String s = stage.replace('-', '_').toUpperCase(Locale.ENGLISH);
     return ApiStages.valueOf(s).url;
@@ -60,7 +61,7 @@ public class ApiUtils {
    *     not occur if the string is well-formed ascii json.
    */
   public static String put(String apiUri, String pathToResource, String body)
-          throws UnsupportedEncodingException {
+      throws UnsupportedEncodingException {
     CloseableHttpClient client = HttpClients.createDefault();
     String fullPath = apiUri + pathToResource;
     HttpPut httpPut = new HttpPut(fullPath);


### PR DESCRIPTION
# What?
I was testing the latest getRequestsByUserId endpoint today, and I realized it wasn't working. I tracked it down to the APIStages endpoint being incorrect in the enum; you can see via this deployment, [for example](https://github.com/PoosdGroup27/poosd-project/runs/4186870149?check_suite_focus=true), that the URIs did not match for prod. I have updated it now.

This PR closes #111.

Edit: FYI I did deploy to test, so if the tests pass, they're gucci.