### PR TITLE
getAllNonUndecidedRequests & MatchStatus enum renaming

### DIFF
--- a/backend/TutorTrade/pom.xml
+++ b/backend/TutorTrade/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.tutor</groupId>
     <artifactId>tutor-api</artifactId>
     <packaging>jar</packaging>
-    <version>adam-dev</version>
+    <version>prod</version>
     <name>tutor-api</name>
 
     <properties>

--- a/backend/TutorTrade/serverless.yml
+++ b/backend/TutorTrade/serverless.yml
@@ -16,7 +16,7 @@ provider:
       Resource: "*"
 
   # change stage when deploying dev stack
-  stage: adam-dev
+  stage: prod
   region: us-east-1
 
 package:

--- a/backend/TutorTrade/src/main/java/com/tutor/chat/Chat.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/chat/Chat.java
@@ -12,7 +12,7 @@ import java.util.*;
 
 @AllArgsConstructor
 @Builder
-@DynamoDBTable(tableName = "chatTable-adam-dev")
+@DynamoDBTable(tableName = "chatTable-prod")
 public class Chat {
   private UUID id;
   private String tuteeId;

--- a/backend/TutorTrade/src/main/java/com/tutor/request/Request.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/request/Request.java
@@ -15,7 +15,7 @@ import java.util.*;
  * Request object. Regarding table name: set equal to requestTable-{stage_name} if deploying to non
  * prod stage.
  */
-@DynamoDBTable(tableName = "requestTable-adam-dev")
+@DynamoDBTable(tableName = "requestTable-prod")
 public class Request {
   private String requesterId;
   private String helperId;

--- a/backend/TutorTrade/src/main/java/com/tutor/user/User.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/user/User.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
  * object before being written to DynamoDB. User data coming from DynamoDB is read into User object.
  * Regarding table name: set equal to userTable-{stage_name} if deploying to none prod stage
  */
-@DynamoDBTable(tableName = "userTable-adam-dev")
+@DynamoDBTable(tableName = "userTable-prod")
 public class User {
   private String name;
 


### PR DESCRIPTION
# What?
This PR exposes a new endpoint, refactors an existing one, and renames the `MatchStatus` enum, as per request from the frontend team.

# How to Use
## MatchStatus enum now has the following values: { UNDECIDED, ACCEPTED, DECLINED, CHATTING, COMPLETED, REVIEWED }

## `requests/getAllNonUndecidedRequests/<userId>` endpoint
- `userId` is a tutor Id
- this contains all matched requests in which a tutor does not have a value of undecided

# Testing
via Postman, and passed all unit tests