### PR TITLE
Fixed Rating Double Conversion Issue

### DIFF
--- a/backend/TutorTrade/src/main/java/com/tutor/user/UserHandler.java
+++ b/backend/TutorTrade/src/main/java/com/tutor/user/UserHandler.java
@@ -274,7 +274,7 @@ public class UserHandler implements RequestStreamHandler {
       userToUpdate.setCumulativeSessionsCompleted(cumulativeSessionsCompleted);
     }
 
-    Double rating = (Double) body.get("rating");
+    Double rating = Double.parseDouble((String) body.get("rating"));
     if (rating != null) {
       userToUpdate.setRating(rating);
     }


### PR DESCRIPTION
# What?
Patches from the app throw ClassCastExceptions b/c we were trying to cast a string to a double. Closes #146 via the backend.

# Testing
via main